### PR TITLE
Openatrium 2.616

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN chmod +x /usr/bin/update_ssmtp.sh
 RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
-ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.635-core.tar.gz
-ENV OATRIUM_DOWNLOAD_SHA256 61b3096dd2cca103f3b2c9e833abc2760b3b135c59239fc01433d529fe046ee8
+ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.641-core.tar.gz
+ENV OATRIUM_DOWNLOAD_SHA256 c8f3c9fa43fbc4032e248d549c2bec2d738c32db807dcbd008374b9be11aa0d7
 RUN rm -f /var/www/html/*
 RUN curl -fsS "$OATRIUM_DOWNLOAD_URL" -o oatrium.tar.gz \
   && echo "$OATRIUM_DOWNLOAD_SHA256 oatrium.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN chmod +x /usr/bin/update_ssmtp.sh
 RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
-ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.634-core.tar.gz
-ENV OATRIUM_DOWNLOAD_SHA256 d089e9c76566c8d2bccf1b56309d83b168ba86f9c8d0b7e6b32e576a12b5cdd5
+ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.635-core.tar.gz
+ENV OATRIUM_DOWNLOAD_SHA256 61b3096dd2cca103f3b2c9e833abc2760b3b135c59239fc01433d529fe046ee8
 RUN rm -f /var/www/html/*
 RUN curl -fsS "$OATRIUM_DOWNLOAD_URL" -o oatrium.tar.gz \
   && echo "$OATRIUM_DOWNLOAD_SHA256 oatrium.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN chmod +x /usr/bin/update_ssmtp.sh && update_ssmtp.sh
 
 # Open Atrium
 RUN rm -f /var/www/html/*
-RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.69-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
+RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.611-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
 
 # Services
 RUN mkdir /etc/service/memcached /etc/service/apache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM phusion/baseimage
-MAINTAINER gabriel schubiner <gabriel.schubiner@gmail.com>
+MAINTAINER starchy grant <starchy@gmail.com>
 
 # Installation
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mysql-client \
     ssmtp \
     memcached \
-	drush
+    drush \
+    git
 
 # Cron
 ADD ./assets/openatrium.cron.sh /etc/cron.hourly/openatrium
@@ -49,9 +50,20 @@ ADD ./assets/update_php_vars.sh /usr/bin/
 RUN chmod +x /usr/bin/update_php_vars.sh 
 RUN update_php_vars.sh
 RUN phpenmod imap
-RUN pecl install -Z uploadprogress && \
-    echo 'extension=uploadprogress.so' >/etc/php/7.0/mods-available/uploadprogress.ini && \
-    phpenmod uploadprogress
+
+# build uploadprogress from git for php7 compatibility
+RUN cd /root \
+    && git clone https://github.com/Jan-E/uploadprogress.git \
+    && cd uploadprogress \
+    && phpize \
+    && ./configure \
+    && make \
+    && make install \
+    && echo 'extension=uploadprogress.so' >/etc/php/7.0/mods-available/uploadprogress.ini \
+    && phpenmod uploadprogress \
+    && cd \
+    && rm -rf /root/uploadprogress
+
 
 # Default ENV vars
 ## Apache

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ ADD assets/apache.openatrium.conf /etc/apache2/sites-available/
 RUN ln -s /etc/apache2/sites-available/apache.openatrium.conf /etc/apache2/sites-enabled/openatrium.conf
 RUN a2enmod rewrite
 
+# Symlink for drush
+RUN mkdir /usr/local/drush
+RUN ln -s /usr/bin/drush /usr/local/drush/drush
+
 # PHP Config
 ENV PHP_MEMORY_LIMIT 1024M
 ENV PHP_MAX_EXECUTION_TIME 900

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN chmod +x /usr/bin/update_ssmtp.sh && update_ssmtp.sh
 
 # Open Atrium
 RUN rm -f /var/www/html/*
-RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.68-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
+RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.69-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
 
 # Services
 RUN mkdir /etc/service/memcached /etc/service/apache

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN chmod +x /usr/bin/update_ssmtp.sh
 RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
-ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.627-core.tar.gz
-ENV OATRIUM_DOWNLOAD_SHA256 4ba2ed50c9e3c8d9b8724c598fe4656e053b449c0447c4fc570afef2c5e907c9
+ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.628-core.tar.gz
+ENV OATRIUM_DOWNLOAD_SHA256 64f40af171ee62a3753b8b4ab993d490086c0f74e4b370e2c80acf4fc9364a07
 RUN rm -f /var/www/html/*
 RUN curl -fsS "$OATRIUM_DOWNLOAD_URL" -o oatrium.tar.gz \
   && echo "$OATRIUM_DOWNLOAD_SHA256 oatrium.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
 # Pinned to 0.9.18 (Ubuntu 14.04 LTS) to enable PHP5
-FROM phusion/baseimage:0.9.18
+FROM phusion/baseimage
 MAINTAINER gabriel schubiner <gabriel.schubiner@gmail.com>
 
 # Installation
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apache2 \
-    libapache2-mod-php5 \
+    libapache2-mod-php \
     build-essential \
-    php5 \
-    php5-dev \
-    php5-mysqlnd \
-    php5-imap \
-    php5-cli \
+    php \
+    php-dev \
+    php-mysqlnd \
+    php-imap \
+    php-cli \
     php-pear \
-    php-apc \
-    php5-gd \
-    php5-memcached \
+    php-apcu \
+    php-gd \
+    php-memcached \
     python-pip \
     mysql-client \
     ssmtp \
@@ -45,14 +45,14 @@ ENV PHP_SENDMAIL_PATH /usr/sbin/ssmtp -t
 RUN sed -i \
     -e 's/^;session.save_path/session.save_path/g' \
     -e "s!^;sendmail_path =.*\$!sendmail_path = $PHP_SENDMAIL_PATH!g" \
-    /etc/php5/apache2/php.ini
+    /etc/php/7.0/apache2/php.ini
 ADD ./assets/update_php_vars.sh /usr/bin/
 RUN chmod +x /usr/bin/update_php_vars.sh 
 RUN update_php_vars.sh
-RUN php5enmod imap
+RUN phpenmod imap
 RUN pecl install -Z uploadprogress && \
-    echo 'extension=uploadprogress.so' >/etc/php5/mods-available/uploadprogress.ini && \
-    php5enmod uploadprogress
+    echo 'extension=uploadprogress.so' >/etc/php/7.0/mods-available/uploadprogress.ini && \
+    phpenmod uploadprogress
 
 # Default ENV vars
 ## Apache

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,13 @@ RUN chmod +x /usr/bin/update_ssmtp.sh
 RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
+ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.627-core.tar.gz
+ENV OATRIUM_DOWNLOAD_SHA256 4ba2ed50c9e3c8d9b8724c598fe4656e053b449c0447c4fc570afef2c5e907c9
 RUN rm -f /var/www/html/*
-RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.618-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
+RUN curl -fsS "$OATRIUM_DOWNLOAD_URL" -o oatrium.tar.gz \
+  && echo "$OATRIUM_DOWNLOAD_SHA256 oatrium.tar.gz" | sha256sum -c - \
+  && tar -C /var/www/html -xzf oatrium.tar.gz --strip-components=1 \
+  && rm -f oatrium.tar.gz
 
 # Services
 RUN mkdir /etc/service/memcached /etc/service/apache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-
+# Pinned to 0.9.18 (Ubuntu 14.04 LTS) to enable PHP5
 FROM phusion/baseimage:0.9.18
 MAINTAINER gabriel schubiner <gabriel.schubiner@gmail.com>
 
@@ -100,7 +100,7 @@ RUN chmod +x /usr/bin/update_ssmtp.sh && update_ssmtp.sh
 
 # Open Atrium
 RUN rm -f /var/www/html/*
-RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.612-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
+RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.614-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
 
 # Services
 RUN mkdir /etc/service/memcached /etc/service/apache

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,8 @@ ENV SSMTP_AUTH_METHOD LOGIN
 ADD ./assets/update_ssmtp.sh /usr/bin/update_ssmtp.sh
 RUN rm -f /etc/ssmtp/ssmtp.conf
 ADD ./assets/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN chmod +x /usr/bin/update_ssmtp.sh && update_ssmtp.sh
+RUN chmod +x /usr/bin/update_ssmtp.sh 
+RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
 RUN rm -f /var/www/html/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN chmod +x /usr/bin/update_ssmtp.sh
 RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
-ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.643-core.tar.gz
-ENV OATRIUM_DOWNLOAD_SHA256 cb80a8362890aa8ce2b0ca4b8bf7f1400e21ab69adc6595da51379bae6d8542c
+ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.644-core.tar.gz
+ENV OATRIUM_DOWNLOAD_SHA256 8373f6f186445705974f3fe00929d409f246d9f1ab6e101bfd22df03231fade6
 RUN rm -f /var/www/html/*
 RUN curl -fsS "$OATRIUM_DOWNLOAD_URL" -o oatrium.tar.gz \
   && echo "$OATRIUM_DOWNLOAD_SHA256 oatrium.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN chmod +x /usr/bin/update_ssmtp.sh && update_ssmtp.sh
 
 # Open Atrium
 RUN rm -f /var/www/html/*
-RUN curl http://ftp.drupal.org/files/projects/openatrium-7.x-2.33-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
+RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.33-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
 
 # Services
 RUN mkdir /etc/service/memcached /etc/service/apache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# Pinned to 0.9.18 (Ubuntu 14.04 LTS) to enable PHP5
 FROM phusion/baseimage
 MAINTAINER gabriel schubiner <gabriel.schubiner@gmail.com>
 
@@ -116,7 +115,7 @@ ADD ./assets/init.sh /etc/my_init.d/10_init.sh
 RUN chmod -R +x /etc/my_init.d/
 
 # Ports
-EXPOSE 22 80 443
+EXPOSE 80 443
 
 # Volumes
 VOLUME /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN chmod +x /usr/bin/update_ssmtp.sh
 RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
-ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.642-core.tar.gz
-ENV OATRIUM_DOWNLOAD_SHA256  17133590ce31bdd82ff6268994e5404dc8f36dda2cf1769e929f41e2343aa90f
+ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.643-core.tar.gz
+ENV OATRIUM_DOWNLOAD_SHA256 cb80a8362890aa8ce2b0ca4b8bf7f1400e21ab69adc6595da51379bae6d8542c
 RUN rm -f /var/www/html/*
 RUN curl -fsS "$OATRIUM_DOWNLOAD_URL" -o oatrium.tar.gz \
   && echo "$OATRIUM_DOWNLOAD_SHA256 oatrium.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-pip \
     mysql-client \
     ssmtp \
-    memcached
+    memcached \
+	drush
 
 # Cron
 ADD ./assets/openatrium.cron.sh /etc/cron.hourly/openatrium
@@ -92,11 +93,6 @@ ADD ./assets/update_ssmtp.sh /usr/bin/update_ssmtp.sh
 RUN rm -f /etc/ssmtp/ssmtp.conf
 ADD ./assets/ssmtp.conf /etc/ssmtp/ssmtp.conf
 RUN chmod +x /usr/bin/update_ssmtp.sh && update_ssmtp.sh
-
-# Drush install
-RUN pear channel-discover pear.drush.org
-
-RUN pear install drush/drush
 
 # Open Atrium
 RUN rm -f /var/www/html/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN chmod +x /usr/bin/update_ssmtp.sh
 RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
-ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.641-core.tar.gz
-ENV OATRIUM_DOWNLOAD_SHA256 c8f3c9fa43fbc4032e248d549c2bec2d738c32db807dcbd008374b9be11aa0d7
+ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.642-core.tar.gz
+ENV OATRIUM_DOWNLOAD_SHA256  17133590ce31bdd82ff6268994e5404dc8f36dda2cf1769e929f41e2343aa90f
 RUN rm -f /var/www/html/*
 RUN curl -fsS "$OATRIUM_DOWNLOAD_URL" -o oatrium.tar.gz \
   && echo "$OATRIUM_DOWNLOAD_SHA256 oatrium.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ RUN chmod -R +x /etc/service/
 # Init script
 ADD ./assets/init.sh /etc/my_init.d/10_init.sh
 RUN chmod -R +x /etc/my_init.d/
+RUN chown www-data /var/www/html/sites/default/files/
 
 # Ports
 EXPOSE 22 80 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
 RUN rm -f /var/www/html/*
-RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.615-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
+RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.616-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
 
 # Services
 RUN mkdir /etc/service/memcached /etc/service/apache

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
 RUN rm -f /var/www/html/*
-RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.616-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
+RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.618-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
 
 # Services
 RUN mkdir /etc/service/memcached /etc/service/apache

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN chmod +x /usr/bin/update_ssmtp.sh
 RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
-ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.628-core.tar.gz
-ENV OATRIUM_DOWNLOAD_SHA256 64f40af171ee62a3753b8b4ab993d490086c0f74e4b370e2c80acf4fc9364a07
+ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.633-core.tar.gz
+ENV OATRIUM_DOWNLOAD_SHA256 9dd7d7460f32518bc79259ce2e6ce69b188292cbb747b142d875eddb3c550c43
 RUN rm -f /var/www/html/*
 RUN curl -fsS "$OATRIUM_DOWNLOAD_URL" -o oatrium.tar.gz \
   && echo "$OATRIUM_DOWNLOAD_SHA256 oatrium.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM starchy/baseimage-docker
 MAINTAINER starchy grant <starchy@gmail.com>
 
 # Installation

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ADD ./assets/openatrium.cron.sh /etc/cron.hourly/openatrium
 RUN chmod +x /etc/cron.hourly/openatrium
 
 # Apache Cfg
+ADD assets/apache.security.conf /etc/apache2/conf.d/
 RUN rm -f /etc/apache2/sites-enabled/*
 ADD assets/apache.openatrium.conf /etc/apache2/sites-available/
 RUN ln -s /etc/apache2/sites-available/apache.openatrium.conf /etc/apache2/sites-enabled/openatrium.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN chmod +x /usr/bin/update_ssmtp.sh && update_ssmtp.sh
 
 # Open Atrium
 RUN rm -f /var/www/html/*
-RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.611-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
+RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.612-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
 
 # Services
 RUN mkdir /etc/service/memcached /etc/service/apache
@@ -112,7 +112,6 @@ RUN chmod -R +x /etc/service/
 # Init script
 ADD ./assets/init.sh /etc/my_init.d/10_init.sh
 RUN chmod -R +x /etc/my_init.d/
-RUN chown www-data /var/www/html/sites/default/files/
 
 # Ports
 EXPOSE 22 80 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN chmod +x /usr/bin/update_ssmtp.sh
 RUN /usr/bin/update_ssmtp.sh
 
 # Open Atrium
-ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.633-core.tar.gz
-ENV OATRIUM_DOWNLOAD_SHA256 9dd7d7460f32518bc79259ce2e6ce69b188292cbb747b142d875eddb3c550c43
+ENV OATRIUM_DOWNLOAD_URL https://ftp.drupal.org/files/projects/openatrium-7.x-2.634-core.tar.gz
+ENV OATRIUM_DOWNLOAD_SHA256 d089e9c76566c8d2bccf1b56309d83b168ba86f9c8d0b7e6b32e576a12b5cdd5
 RUN rm -f /var/www/html/*
 RUN curl -fsS "$OATRIUM_DOWNLOAD_URL" -o oatrium.tar.gz \
   && echo "$OATRIUM_DOWNLOAD_SHA256 oatrium.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN chmod +x /usr/bin/update_ssmtp.sh && update_ssmtp.sh
 
 # Open Atrium
 RUN rm -f /var/www/html/*
-RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.33-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
+RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.68-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
 
 # Services
 RUN mkdir /etc/service/memcached /etc/service/apache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM phusion/baseimage
+FROM phusion/baseimage:0.9.18
 MAINTAINER gabriel schubiner <gabriel.schubiner@gmail.com>
 
 # Installation

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN chmod +x /usr/bin/update_ssmtp.sh && update_ssmtp.sh
 
 # Open Atrium
 RUN rm -f /var/www/html/*
-RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.614-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
+RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.615-core.tar.gz | tar xz -C /var/www/html --strip-components=1 
 
 # Services
 RUN mkdir /etc/service/memcached /etc/service/apache

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.628
+## OpenAtrium - ver. 2.633
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.628-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.633-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.612
+## OpenAtrium - ver. 2.614
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.612-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.614-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.30RC3
+## OpenAtrium - ver. 2.69
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,11 +177,11 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl http://ftp.drupal.org/files/projects/openatrium-7.x-2.30-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.69-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 
-`RUN curl http://ftp.drupal.org/files/projects/<distribution_name>-7.x-<distribution_version>-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/<distribution_name>-7.x-<distribution_version>-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 I should probably take this piece out into the init.sh script, and make the distribution name and version specifiable by environment variables, so you could literally use this image for any Drupal 7 distribution without rebuilding it, but maybe later.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.643
+## OpenAtrium - ver. 2.644
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.643-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.644-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.641
+## OpenAtrium - ver. 2.642
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.641-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.642-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.69
+## OpenAtrium - ver. 2.611
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.69-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.611-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.627
+## OpenAtrium - ver. 2.628
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.627-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.628-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.611
+## OpenAtrium - ver. 2.612
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.611-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.612-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.633
+## OpenAtrium - ver. 2.634
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.633-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.634-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.618
+## OpenAtrium - ver. 2.627
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.618-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.627-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.635
+## OpenAtrium - ver. 2.641
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.635-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.641-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.642
+## OpenAtrium - ver. 2.643
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.642-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.643-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.614
+## OpenAtrium - ver. 2.615
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.614-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.615-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.634
+## OpenAtrium - ver. 2.635
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.634-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.635-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.616
+## OpenAtrium - ver. 2.618
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.616-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.618-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains a working repository for Phase2's OpenAtrium, based on the Drupal CMS.
 
-## OpenAtrium - ver. 2.615
+## OpenAtrium - ver. 2.616
 
 OpenAtrium is a pretty rad Drupal distribution, supported by Phase2, that makes it pretty easy to set up very flexible intranets/community sites with out-of-the-box support for maintaining a hierarchy of 'spaces' that can each be customized with calendars, tasks, discussion boards, and file sharing. User groups, teams, permissions, etc. all well supported. 
 
@@ -177,7 +177,7 @@ Last Note: 99% of this image is relevant to any Drupal 7 distribution, so if you
 
 You'll want to change this line: 
 
-`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.615-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
+`RUN curl https://ftp.drupal.org/files/projects/openatrium-7.x-2.616-core.tar.gz | tar xz -C /var/www/html --strip-components=1 `
 
 to 
 

--- a/assets/apache.security.conf
+++ b/assets/apache.security.conf
@@ -1,0 +1,3 @@
+ServerTokens Prod
+ServerSignature Off
+TraceEnable Off

--- a/assets/init.sh
+++ b/assets/init.sh
@@ -60,6 +60,7 @@ function restore_permissions {
     
     pushd sites
     find . -type d -name files -exec chmod 770 '{}' \;
+    find ./default/files -type d -exec chown -R www-data '{}' \;
     find ./default/files -type d -exec chmod 770 '{}' \;
     find ./default/files -type f -exec chmod 660 '{}' \;
 

--- a/assets/update_php_vars.sh
+++ b/assets/update_php_vars.sh
@@ -7,10 +7,10 @@ sed -i \
     -e "s/^max_execution_time.*\$/max_execution_time = $PHP_MAX_EXECUTION_TIME/g" \
     -e "s/^session.save_handler.*\$/session.save_handler = $PHP_SESSION_SAVE_CACHE/g" \
     -e "s!^sendmail_path.*\$!sendmail_path = $PHP_SENDMAIL_PATH!g" \
-    /etc/php5/apache2/php.ini
+    /etc/php/7.0/apache2/php.ini
 
 if [ "$PHP_SESSION_SAVE_CACHE" == "memcached" ]; then
-    sed -i -e "s!^session.save_path.*\$!session.save_path = \"localhost:11211\"!g"  /etc/php5/apache2/php.ini
+    sed -i -e "s!^session.save_path.*\$!session.save_path = \"localhost:11211\"!g"  /etc/php/7.0/apache2/php.ini
 else 
-    sed -i -e "s!^session.save_path.*\$!session.save_path = \"/var/lib/php5\"!g" /etc/php5/apache2/php.ini
+    sed -i -e "s!^session.save_path.*\$!session.save_path = \"/var/lib/php\"!g" /etc/php/7.0/apache2/php.ini
 fi

--- a/assets/update_php_vars.sh
+++ b/assets/update_php_vars.sh
@@ -2,6 +2,7 @@
 
 
 sed -i \
+    -e "s/^expose_php.*\$/expose_php = Off/g" \
     -e "s/^memory_limit.*\$/memory_limit = $PHP_MEMORY_LIMIT/g" \
     -e "s/^max_execution_time.*\$/max_execution_time = $PHP_MAX_EXECUTION_TIME/g" \
     -e "s/^session.save_handler.*\$/session.save_handler = $PHP_SESSION_SAVE_CACHE/g" \

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,0 +1,26 @@
+openatrium:
+  image: starchy/openatrium # not currently on dockerhub
+  links:
+    - mariadb
+  environment:
+    DB_NAME: openatrium
+    INSTALL_SITE: "false" # set to true for automatic install on first run only
+    MIGRATE_SITES_TO: /sites
+  volumes:
+    - ./sites:/sites
+    - ./ssmtp.conf:/etc/ssmtp/ssmtp.conf:ro
+  ports:
+    - "80:80"
+  restart: always
+
+mariadb:
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: openatrium
+    MYSQL_USER: openatrium
+    MYSQL_PASSWORD: changeme
+    MYSQL_ROOT_PASSWORD: changemetoo
+  volumes:
+    - ./mysql:/var/lib/mysql
+  restart: always
+


### PR DESCRIPTION
Fixes build by pinning phusion to pre-Xenial version and fixing installs for drush and OA, and updates OA to 2.614.